### PR TITLE
Add bluetooth for monitoring and calibration

### DIFF
--- a/micras_hal/include/micras/hal/uart_dma.hpp
+++ b/micras_hal/include/micras/hal/uart_dma.hpp
@@ -1,0 +1,71 @@
+/**
+ * @file uart_dma.hpp
+ *
+ * @brief HAL UART DMA class header
+ *
+ * @date 09/2024
+ */
+
+#ifndef MICRAS_HAL_UART_DMA_HPP
+#define MICRAS_HAL_UART_DMA_HPP
+
+#include <cstdint>
+#include <span>
+#include <usart.h>
+
+namespace micras::hal {
+/**
+ * @brief Class to handle UART DMA on STM32 microcontrollers
+ */
+class UartDma {
+public:
+    /**
+     * @brief UART configuration struct
+     */
+    struct Config {
+        void (*init_function)();
+        UART_HandleTypeDef* handle;
+    };
+
+    /**
+     * @brief Construct a new UartDma object
+     *
+     * @param config Configuration for the UART
+     */
+    explicit UartDma(const Config& config);
+
+    /**
+     * @brief Start the TX DMA transfer
+     *
+     * @param buffer Buffer to transmit
+     */
+    void start_tx_dma(std::span<uint8_t> buffer);
+
+    /**
+     * @brief Start the RX DMA transfer
+     *
+     * @param buffer Buffer to receive data into
+     */
+    void start_rx_dma(std::span<uint8_t> buffer);
+
+    /**
+     * @brief Stop the RX DMA transfer
+     */
+    void stop_rx_dma();
+
+    /**
+     * @brief Get the number of bytes left in the buffer
+     *
+     * @return uint16_t Number of bytes left in the buffer
+     */
+    uint16_t get_rx_dma_counter() const;
+
+private:
+    /**
+     * @brief Handle for the UART
+     */
+    UART_HandleTypeDef* handle;
+};
+}  // namespace micras::hal
+
+#endif  // MICRAS_HAL_UART_DMA_HPP

--- a/micras_hal/include/micras/hal/uart_dma.hpp
+++ b/micras_hal/include/micras/hal/uart_dma.hpp
@@ -54,6 +54,13 @@ public:
     void stop_rx_dma();
 
     /**
+     * @brief Check if the TX is busy
+     *
+     * @return true TX is busy, false otherwise
+     */
+    bool is_tx_busy() const;
+
+    /**
      * @brief Get the number of bytes left in the buffer
      *
      * @return uint16_t Number of bytes left in the buffer

--- a/micras_hal/src/uart_dma.cpp
+++ b/micras_hal/src/uart_dma.cpp
@@ -1,0 +1,31 @@
+/**
+ * @file uart_dma.cpp
+ *
+ * @brief HAL UART DMA class source
+ *
+ * @date 09/2024
+ */
+
+#include "micras/hal/uart_dma.hpp"
+
+namespace micras::hal {
+UartDma::UartDma(const UartDma::Config& config) : handle{config.handle} {
+    config.init_function();
+}
+
+void UartDma::start_tx_dma(std::span<uint8_t> buffer) {
+    HAL_UART_Transmit_DMA(this->handle, buffer.data(), buffer.size());
+}
+
+void UartDma::start_rx_dma(std::span<uint8_t> buffer) {
+    HAL_UART_Receive_DMA(this->handle, buffer.data(), buffer.size());
+}
+
+void UartDma::stop_rx_dma() {
+    HAL_UART_AbortReceive(this->handle);
+}
+
+uint16_t UartDma::get_rx_dma_counter() const {
+    return __HAL_DMA_GET_COUNTER(this->handle->hdmarx);
+}
+}  // namespace micras::hal

--- a/micras_hal/src/uart_dma.cpp
+++ b/micras_hal/src/uart_dma.cpp
@@ -25,6 +25,10 @@ void UartDma::stop_rx_dma() {
     HAL_UART_AbortReceive(this->handle);
 }
 
+bool UartDma::is_tx_busy() const {
+    return this->handle->gState == HAL_UART_STATE_BUSY_TX;
+}
+
 uint16_t UartDma::get_rx_dma_counter() const {
     return __HAL_DMA_GET_COUNTER(this->handle->hdmarx);
 }

--- a/micras_proxy/include/micras/proxy/bluetooth.hpp
+++ b/micras_proxy/include/micras/proxy/bluetooth.hpp
@@ -242,7 +242,7 @@ private:
     /**
      * @brief Size of the UART buffers
      */
-    static constexpr uint8_t buffer_max_size{50};
+    static constexpr uint8_t buffer_max_size{1000};
 
     /**
      * @brief UART for the bluetooth connection

--- a/micras_proxy/include/micras/proxy/bluetooth.hpp
+++ b/micras_proxy/include/micras/proxy/bluetooth.hpp
@@ -112,7 +112,9 @@ private:
      *     5     6   8*sizeof(T)   5
      * | BEGIN | ID |   VALUE   | END |
      *
-     * @tparam T
+     * The ACK message has ID 0 and the value is the ID of the message to be acknowledged
+     *
+     * @tparam T Type of the variable to send
      */
     template <typename T>
     union TxMessage {
@@ -211,6 +213,33 @@ private:
     }
 
     /**
+     * @brief Write a variable to the tx_buffer
+     *
+     * @param start_byte Start byte of the message on the buffer
+     * @param id ID of the variable
+     * @param variable Variable to send
+     */
+    static constexpr void send_variable(uint8_t& start_byte, uint8_t id, std::span<uint8_t> variable) {
+        switch (variable.size()) {
+            case 1:
+                write_tx_frame<uint8_t>(start_byte, id, variable.data());
+                break;
+
+            case 2:
+                write_tx_frame<uint16_t>(start_byte, id, variable.data());
+                break;
+
+            case 4:
+                write_tx_frame<uint32_t>(start_byte, id, variable.data());
+                break;
+
+            case 8:
+                write_tx_frame<uint64_t>(start_byte, id, variable.data());
+                break;
+        }
+    }
+
+    /**
      * @brief Size of the UART buffers
      */
     static constexpr uint8_t buffer_max_size{50};
@@ -227,9 +256,10 @@ private:
     std::array<uint8_t, buffer_max_size> tx_buffer{};
 
     /**
-     * @brief Cursor for navigating the rx_buffer
+     * @brief Cursor for navigating the buffers
      */
     uint16_t rx_cursor;
+    uint16_t tx_cursor;
 
     /**
      * @brief Map for storing the variables to send

--- a/micras_proxy/include/micras/proxy/bluetooth.hpp
+++ b/micras_proxy/include/micras/proxy/bluetooth.hpp
@@ -141,11 +141,6 @@ private:
     Status process_message();
 
     /**
-     * @brief Send all the variables through the Bluetooth
-     */
-    void send_variables();
-
-    /**
      * @brief Validate the checksum of the message
      *
      * @param data Data to check

--- a/micras_proxy/include/micras/proxy/bluetooth.hpp
+++ b/micras_proxy/include/micras/proxy/bluetooth.hpp
@@ -1,0 +1,189 @@
+/**
+ * @file bluetooth.hpp
+ *
+ * @brief Proxy Bluetooth class declaration
+ *
+ * @date 09/2024
+ */
+
+#ifndef MICRAS_PROXY_BLUETOOTH_HPP
+#define MICRAS_PROXY_BLUETOOTH_HPP
+
+#include <array>
+#include <cstdint>
+#include <span>
+#include <unordered_map>
+
+#include "micras/hal/uart_dma.hpp"
+
+namespace micras::proxy {
+/**
+ * @brief Class for controlling the Bluetooth communication
+ *
+ * @todo Add ACK to received messages
+ */
+class Bluetooth {
+public:
+    /**
+     * @brief Construct a new Bluetooth object
+     *
+     * @param config Configuration for the UART communication
+     */
+    Bluetooth(const hal::UartDma::Config& config);
+
+    /**
+     * @brief Process all received messages and send chosen variables
+     */
+    void update();
+
+private:
+    /**
+     * @brief Union for representing the received messages
+     * Follows the protocol:
+     *
+     *     7      1       32       2     6         1        7
+     * | BEGIN | READ | ADDRESS | SIZE | ID | START/STOP | END |
+     *
+     *     7       1       32       2     8*2^SIZE     7        7
+     * | BEGIN | WRITE | ADDRESS | SIZE |  VALUE  | CHECKSUM | END |
+     */
+    union RxMessage {
+        enum Size : uint8_t {
+            BYTE,
+            HALF_WORD,
+            WORD,
+            DOUBLE_WORD,
+        };
+
+        enum RW : uint8_t {
+            READ = 0,
+            WRITE = 1,
+        };
+
+        enum StartStop : uint8_t {
+            STOP = 0,
+            START = 1,
+        };
+
+        static constexpr uint8_t begin_bits_mask{0xFE};
+
+        struct Symbols {
+            static constexpr uint8_t begin{0x42};
+            static constexpr uint8_t end{0x7F};
+        };
+
+        struct __attribute__((__packed__)) Fields {
+            union Type {
+                struct __attribute__((__packed__)) Read {
+                    uint8_t id         : 6;
+                    uint8_t start_stop : 1;
+                    uint8_t end        : 7;
+                };
+
+                template <typename T>
+                struct __attribute__((__packed__)) Write {
+                    T       value    : 8 * sizeof(T);
+                    uint8_t checksum : 7;
+                    uint8_t end      : 7;
+                };
+
+                Read            read;
+                Write<uint8_t>  write_byte;
+                Write<uint16_t> write_half_word;
+                Write<uint32_t> write_word;
+                Write<uint64_t> write_double_word;
+            };
+
+            uint8_t  begin   : 7;
+            RW       rw      : 1;
+            uint32_t address : 32;
+            Size     size    : 2;
+            Type     type;
+        };
+
+        Fields  fields;
+        uint8_t data[15];
+    };
+
+    /**
+     * @brief Union for representing the messages to be sent
+     * Follows the protocol:
+     *
+     *     5     6   8*sizeof(T)   5
+     * | BEGIN | ID |   VALUE   | END |
+     *
+     * @tparam T
+     */
+    template <typename T>
+    union TxMessage {
+        struct __attribute__((__packed__)) Fields {
+            uint8_t begin : 5 = 0x19;
+            uint8_t id    : 6;
+            T       value : 8 * sizeof(T);
+            uint8_t end   : 5 = 0x13;
+        };
+
+        Fields  fields;
+        uint8_t data[sizeof(T) + 2];
+    };
+
+    /**
+     * @brief Enum for representing the status of the message processing
+     */
+    enum Status {
+        OK,
+        NO_MESSAGE,
+        INVALID_MESSAGE
+    };
+
+    /**
+     * @brief Process a single message from the rx_buffer
+     *
+     * @return Status Status of the message processed
+     */
+    Status process_message();
+
+    /**
+     * @brief Validate the checksum of the message
+     *
+     * @param data Data to check
+     * @param checksum Checksum to validate
+     *
+     * @return true if the checksum is valid, false otherwise
+     */
+    bool validate_checksum(uint64_t data, uint8_t checksum);
+
+    /**
+     * @brief Send all the variables through the Bluetooth
+     */
+    void send_variables();
+
+    /**
+     * @brief Size of the UART buffers
+     */
+    static constexpr uint8_t buffer_max_size{50};
+
+    /**
+     * @brief UART for the bluetooth connection
+     */
+    hal::UartDma uart;
+
+    /**
+     * @brief Buffers for the UART communication
+     */
+    std::array<uint8_t, buffer_max_size> rx_buffer{};
+    std::array<uint8_t, buffer_max_size> tx_buffer{};
+
+    /**
+     * @brief Cursor for navigating the rx_buffer
+     */
+    uint16_t rx_cursor;
+
+    /**
+     * @brief Map for storing the variables to send
+     */
+    std::unordered_map<uint8_t, std::span<uint8_t>> variable_dict;
+};
+}  // namespace micras::proxy
+
+#endif  // MICRAS_PROXY_BLUETOOTH_HPP

--- a/micras_proxy/include/micras/proxy/bluetooth.hpp
+++ b/micras_proxy/include/micras/proxy/bluetooth.hpp
@@ -204,11 +204,11 @@ private:
      * @param variable_address Address of the variable on the memory
      */
     template <typename T>
-    static constexpr void write_tx_frame(uint8_t& start_byte, uint8_t id, uint8_t* variable_address) {
+    static constexpr void write_tx_frame(uint8_t& start_byte, uint8_t id, uint8_t* const variable_address) {
         TxMessage<T>& message = reinterpret_cast<TxMessage<T>&>(start_byte);
         message.fields.begin = TxMessage<T>::Symbols::begin;
         message.fields.id = id;
-        message.fields.value = *std::bit_cast<T*>(variable_address);
+        message.fields.value = *std::bit_cast<T* const>(variable_address);
         message.fields.end = TxMessage<T>::Symbols::end;
     }
 
@@ -242,7 +242,7 @@ private:
     /**
      * @brief Size of the UART buffers
      */
-    static constexpr uint8_t buffer_max_size{1000};
+    static constexpr uint16_t buffer_max_size{1000};
 
     /**
      * @brief UART for the bluetooth connection

--- a/micras_proxy/src/bluetooth.cpp
+++ b/micras_proxy/src/bluetooth.cpp
@@ -8,6 +8,10 @@ Bluetooth::Bluetooth(const hal::UartDma::Config& config) : uart(config) {
 }
 
 void Bluetooth::update() {
+    if (this->uart.is_tx_busy()) {
+        return;
+    }
+
     this->rx_cursor = 0;
     this->tx_cursor = 0;
 
@@ -18,10 +22,6 @@ void Bluetooth::update() {
     }
 
     this->uart.start_rx_dma(this->rx_buffer);
-
-    if (this->uart.is_tx_busy()) {
-        return;
-    }
 
     for (const auto& [id, variable] : this->variable_dict) {
         send_variable(this->tx_buffer.at(this->tx_cursor), id, variable);

--- a/micras_proxy/src/bluetooth.cpp
+++ b/micras_proxy/src/bluetooth.cpp
@@ -31,8 +31,7 @@ Bluetooth::Status Bluetooth::process_message() {
     }
 
     const RxMessage& message = reinterpret_cast<const RxMessage&>(this->rx_buffer.at(this->rx_cursor));
-
-    RxMessage::Size size = message.fields.size;
+    RxMessage::Size  size = message.fields.size;
 
     if (message.fields.rw == RxMessage::RW::READ) {
         if (message.fields.type.read.end != RxMessage::Symbols::end) {
@@ -46,23 +45,25 @@ Bluetooth::Status Bluetooth::process_message() {
         } else {
             this->variable_dict.erase(id);
         }
-    } else {
-        switch (size) {
-            case RxMessage::Size::BYTE:
-                return receive_variable<uint8_t>(message.fields.address, message.fields.type.write_byte);
 
-            case RxMessage::Size::HALF_WORD:
-                return receive_variable<uint16_t>(message.fields.address, message.fields.type.write_half_word);
-
-            case RxMessage::Size::WORD:
-                return receive_variable<uint32_t>(message.fields.address, message.fields.type.write_word);
-
-            case RxMessage::Size::DOUBLE_WORD:
-                return receive_variable<uint64_t>(message.fields.address, message.fields.type.write_double_word);
-        }
+        return Status::OK;
     }
 
-    return Status::OK;
+    switch (size) {
+        case RxMessage::Size::BYTE:
+            return receive_variable<uint8_t>(message.fields.address, message.fields.type.write_byte);
+
+        case RxMessage::Size::HALF_WORD:
+            return receive_variable<uint16_t>(message.fields.address, message.fields.type.write_half_word);
+
+        case RxMessage::Size::WORD:
+            return receive_variable<uint32_t>(message.fields.address, message.fields.type.write_word);
+
+        case RxMessage::Size::DOUBLE_WORD:
+            return receive_variable<uint64_t>(message.fields.address, message.fields.type.write_double_word);
+    }
+
+    return Status::INVALID_MESSAGE;
 }
 
 void Bluetooth::send_variables() {

--- a/micras_proxy/src/bluetooth.cpp
+++ b/micras_proxy/src/bluetooth.cpp
@@ -1,0 +1,170 @@
+#include <bit>
+
+#include "micras/proxy/bluetooth.hpp"
+
+namespace micras::proxy {
+Bluetooth::Bluetooth(const hal::UartDma::Config& config) : uart(config) {
+    this->uart.start_rx_dma(this->rx_buffer);
+}
+
+void Bluetooth::update() {
+    this->uart.stop_rx_dma();
+    this->rx_cursor = 0;
+
+    while (this->process_message() != Status::NO_MESSAGE) {
+        this->rx_cursor++;
+    }
+
+    this->uart.start_rx_dma(this->rx_buffer);
+    this->send_variables();
+}
+
+Bluetooth::Status Bluetooth::process_message() {
+    uint16_t received_bytes = this->rx_buffer.size() - this->uart.get_rx_dma_counter() - 1;
+
+    while ((this->rx_buffer.at(this->rx_cursor) & RxMessage::begin_bits_mask) != RxMessage::Symbols::begin) {
+        if (this->rx_cursor >= received_bytes) {
+            return Status::NO_MESSAGE;
+        }
+
+        this->rx_cursor++;
+    }
+
+    const RxMessage& message = reinterpret_cast<const RxMessage&>(this->rx_buffer.at(this->rx_cursor));
+
+    RxMessage::Size size = message.fields.size;
+
+    if (message.fields.rw == RxMessage::RW::READ) {
+        if (message.fields.type.read.end != RxMessage::Symbols::end) {
+            return Status::INVALID_MESSAGE;
+        }
+
+        uint8_t id = message.fields.type.read.id;
+
+        if (message.fields.type.read.start_stop == RxMessage::StartStop::START) {
+            this->variable_dict[id] = std::span<uint8_t>(std::bit_cast<uint8_t*>(message.fields.address), 1 << size);
+        } else {
+            this->variable_dict.erase(id);
+        }
+    } else {
+        switch (size) {
+            case RxMessage::Size::BYTE: {
+                uint8_t write_value = message.fields.type.write_byte.value;
+
+                if (not validate_checksum(
+                        message.fields.address ^ write_value, message.fields.type.write_byte.checksum
+                    )) {
+                    return Status::INVALID_MESSAGE;
+                }
+
+                if (message.fields.type.write_byte.end != RxMessage::Symbols::end) {
+                    return Status::INVALID_MESSAGE;
+                }
+
+                uint8_t* address = std::bit_cast<uint8_t*>(message.fields.address);
+                *address = write_value;
+                break;
+            }
+            case RxMessage::Size::HALF_WORD: {
+                uint16_t write_value = message.fields.type.write_half_word.value;
+
+                if (not validate_checksum(
+                        message.fields.address ^ write_value, message.fields.type.write_half_word.checksum
+                    )) {
+                    return Status::INVALID_MESSAGE;
+                }
+
+                if (message.fields.type.write_half_word.end != RxMessage::Symbols::end) {
+                    return Status::INVALID_MESSAGE;
+                }
+
+                uint16_t* address = std::bit_cast<uint16_t*>(message.fields.address);
+                *address = write_value;
+                break;
+            }
+            case RxMessage::Size::WORD: {
+                uint32_t write_value = message.fields.type.write_word.value;
+
+                if (not validate_checksum(
+                        message.fields.address ^ write_value, message.fields.type.write_word.checksum
+                    )) {
+                    return Status::INVALID_MESSAGE;
+                }
+
+                if (message.fields.type.write_word.end != RxMessage::Symbols::end) {
+                    return Status::INVALID_MESSAGE;
+                }
+
+                uint32_t* address = std::bit_cast<uint32_t*>(message.fields.address);
+                *address = write_value;
+                break;
+            }
+            case RxMessage::Size::DOUBLE_WORD: {
+                uint64_t write_value = message.fields.type.write_double_word.value;
+
+                if (not validate_checksum(
+                        message.fields.address ^ write_value, message.fields.type.write_double_word.checksum
+                    )) {
+                    return Status::INVALID_MESSAGE;
+                }
+
+                if (message.fields.type.write_double_word.end != RxMessage::Symbols::end) {
+                    return Status::INVALID_MESSAGE;
+                }
+
+                uint64_t* address = std::bit_cast<uint64_t*>(message.fields.address);
+                *address = write_value;
+                break;
+            }
+        }
+    }
+
+    return Status::OK;
+}
+
+bool Bluetooth::validate_checksum(uint64_t data, uint8_t checksum) {
+    for (uint8_t i = 0; i < 8; i++) {
+        checksum ^= data >> (i * 8);
+    }
+
+    return checksum == 0xFF;
+}
+
+void Bluetooth::send_variables() {
+    uint16_t tx_cursor = 0;
+
+    for (auto& [id, variable] : this->variable_dict) {
+        switch (variable.size()) {
+            case 1: {
+                TxMessage<uint8_t>& message = reinterpret_cast<TxMessage<uint8_t>&>(this->tx_buffer.at(tx_cursor));
+                message.fields.id = id;
+                message.fields.value = variable[0];
+                break;
+            }
+            case 2: {
+                TxMessage<uint16_t>& message = reinterpret_cast<TxMessage<uint16_t>&>(this->tx_buffer.at(tx_cursor));
+                message.fields.id = id;
+                message.fields.value = *std::bit_cast<uint16_t*>(variable.data());
+                break;
+            }
+            case 4: {
+                TxMessage<uint32_t>& message = reinterpret_cast<TxMessage<uint32_t>&>(this->tx_buffer.at(tx_cursor));
+                message.fields.id = id;
+                message.fields.value = *std::bit_cast<uint32_t*>(variable.data());
+                break;
+            }
+            case 8: {
+                TxMessage<uint64_t>& message = reinterpret_cast<TxMessage<uint64_t>&>(this->tx_buffer.at(tx_cursor));
+                message.fields.id = id;
+                message.fields.value = *std::bit_cast<uint64_t*>(variable.data());
+                break;
+            }
+        }
+
+        tx_cursor += variable.size() + 2;
+    }
+
+    this->uart.start_tx_dma({this->tx_buffer.data(), tx_cursor});
+}
+
+}  // namespace micras::proxy

--- a/micras_proxy/src/bluetooth.cpp
+++ b/micras_proxy/src/bluetooth.cpp
@@ -23,7 +23,7 @@ void Bluetooth::update() {
         return;
     }
 
-    for (auto& [id, variable] : this->variable_dict) {
+    for (const auto& [id, variable] : this->variable_dict) {
         send_variable(this->tx_buffer.at(this->tx_cursor), id, variable);
         this->tx_cursor += variable.size() + 2;
     }
@@ -58,7 +58,7 @@ Bluetooth::Status Bluetooth::process_message() {
             this->variable_dict.erase(id);
         }
 
-        send_variable(this->tx_buffer.at(this->tx_cursor), 0, {id});
+        send_variable(this->tx_buffer.at(this->tx_cursor), 0, {&id, 1});
         return Status::OK;
     }
 


### PR DESCRIPTION
Essa PR adiciona a classe de Bluetooth, que é capaz de ler e escrever em qualquer endereço de memória do código, de forma que ao se comunicar com uma interface sendo executada em um computador, será possível monitorar e alterar o valor de qualquer variável estática do código.