### PR TITLE
Feature/maze algorithms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ cube/*
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,c++
+
+### Clangd ###
+.clangd

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,9 +19,6 @@
 
     "clangd.arguments": [
         "--pretty",
-        "--clang-tidy",
         "--compile-commands-dir=${workspaceFolder}/build/",
-        "--enable-config",
-        "--query-driver=/usr/bin/arm-none-eabi-g++"
     ]
 }

--- a/config/constants.hpp
+++ b/config/constants.hpp
@@ -95,7 +95,7 @@ const nav::Maze::Config maze_config{
         {maze_width / 2, (maze_height - 1) / 2},
         {(maze_width - 1) / 2, (maze_height - 1) / 2},
     }},
-    .cost_margin = 5,
+    .cost_margin = 1.2F,
 };
 
 const nav::Odometry::Config odometry_config{

--- a/config/constants.hpp
+++ b/config/constants.hpp
@@ -28,6 +28,7 @@ constexpr float    start_offset{0.04F + wall_thickness / 2.0F};
 constexpr float    exploration_speed{0.5F};
 constexpr float    max_linear_acceleration{1.0F};
 constexpr float    max_angular_acceleration{200.0F};
+constexpr float    crash_acceleration{20.0F};
 
 constexpr core::WallSensorsIndex wall_sensors_index{
     .left_front = 0,

--- a/config/constants.hpp
+++ b/config/constants.hpp
@@ -95,7 +95,7 @@ const nav::Maze::Config maze_config{
         {maze_width / 2, (maze_height - 1) / 2},
         {(maze_width - 1) / 2, (maze_height - 1) / 2},
     }},
-    .cost_margin = 10,
+    .cost_margin = 5,
 };
 
 const nav::Odometry::Config odometry_config{

--- a/config/constants.hpp
+++ b/config/constants.hpp
@@ -6,7 +6,6 @@
 #define MICRAS_CONSTANTS_HPP
 
 #include <cstdint>
-#include <numbers>
 
 #include "micras/nav/action_queuer.hpp"
 #include "micras/nav/follow_wall.hpp"

--- a/config/constants.hpp
+++ b/config/constants.hpp
@@ -95,6 +95,7 @@ const nav::Maze::Config maze_config{
         {maze_width / 2, (maze_height - 1) / 2},
         {(maze_width - 1) / 2, (maze_height - 1) / 2},
     }},
+    .cost_margin = 10,
 };
 
 const nav::Odometry::Config odometry_config{

--- a/include/micras/micras.hpp
+++ b/include/micras/micras.hpp
@@ -74,6 +74,13 @@ public:
     void reset();
 
     /**
+     * @brief Use the imu to check if the robot crashed.
+     *
+     * @return True if the robot crashed, false otherwise.
+     */
+    bool check_crash() const;
+
+    /**
      * @brief Get the current objective of the robot.
      *
      * @return The current objective of the robot.

--- a/include/micras/states/error.hpp
+++ b/include/micras/states/error.hpp
@@ -13,15 +13,19 @@ public:
     using BaseState::BaseState;
 
     /**
+     * @brief Execute the entry function of this state.
+     */
+    void on_entry() override {
+        this->micras.stop();
+        this->micras.send_event(Interface::Event::ERROR);
+    }
+
+    /**
      * @brief Execute this state.
      *
      * @return The id of the next state.
      */
-    uint8_t execute() override {
-        this->micras.send_event(Interface::Event::ERROR);
-
-        return this->get_id();
-    }
+    uint8_t execute() override { return this->get_id(); }
 };
 }  // namespace micras
 

--- a/include/micras/states/run.hpp
+++ b/include/micras/states/run.hpp
@@ -26,6 +26,10 @@ public:
      * @return The id of the next state.
      */
     uint8_t execute() override {
+        if (this->micras.check_crash()) {
+            return Micras::State::ERROR;
+        }
+
         if (not this->micras.run()) {
             return this->get_id();
         }

--- a/include/micras/states/run.hpp
+++ b/include/micras/states/run.hpp
@@ -37,6 +37,7 @@ public:
         switch (this->micras.get_objective()) {
             case core::Objective::EXPLORE:
                 this->micras.set_objective(core::Objective::RETURN);
+                this->micras.save_best_route();
                 return Micras::State::WAIT_FOR_RUN;
 
             case core::Objective::RETURN:

--- a/micras_core/include/micras/core/vector.hpp
+++ b/micras_core/include/micras/core/vector.hpp
@@ -1,0 +1,89 @@
+/**
+ * @file
+ */
+
+#ifndef MICRAS_CORE_VECTOR_HPP
+#define MICRAS_CORE_VECTOR_HPP
+
+namespace micras::core {
+/**
+ * @brief Type to store a point in 2D space.
+ */
+struct Vector {
+    /**
+     * @brief Calculate the distance to another point.
+     *
+     * @param other The other point.
+     * @return The distance to the other point.
+     */
+    float distance(const Vector& other) const;
+
+    /**
+     * @brief Calculate the distance of the point to the origin.
+     *
+     * @return The distance of the point to the origin.
+     */
+    float magnitude() const;
+
+    /**
+     * @brief Calculate the angle between two points.
+     *
+     * @param other The other point.
+     * @return The angle between the two points.
+     */
+    float angle_between(const Vector& other) const;
+
+    /**
+     * @brief Move the point towards another point by a given distance.
+     *
+     * @param other The point to move towards.
+     * @param distance The distance to move.
+     * @return The point after moving towards the other point.
+     */
+    Vector move_towards(const Vector& other, float distance) const;
+
+    /**
+     * @brief Add a point to another.
+     *
+     * @param other The point to add.
+     * @return The result of the addition.
+     */
+    Vector operator+(const Vector& other) const;
+
+    /**
+     * @brief Subtract a point from another.
+     *
+     * @param other The point to subtract.
+     * @return The result of the subtraction.
+     */
+    Vector operator-(const Vector& other) const;
+
+    /**
+     * @brief Compare two points for equality.
+     *
+     * @param other The other point to compare.
+     * @return True if the points are equal, false otherwise.
+     */
+    bool operator==(const Vector& other) const;
+
+    /**
+     * @brief Calculate the remainder of the division of the point by a value.
+     *
+     * @param value The value to divide the point by.
+     * @return The remainder of the division.
+     */
+    Vector operator%(float value) const;
+
+    /**
+     * @brief The x coordinate of the point in 2D space.
+     */
+    float x;
+
+    /**
+     * @brief The y coordinate of the point in 2D space.
+     */
+    float y;
+};
+}  // namespace micras::core
+
+#endif  // MICRAS_CORE_VECTOR_HPP

--- a/micras_core/src/vector.cpp
+++ b/micras_core/src/vector.cpp
@@ -3,7 +3,6 @@
  */
 
 #include <cmath>
-#include <numbers>
 
 #include "micras/core/vector.hpp"
 

--- a/micras_core/src/vector.cpp
+++ b/micras_core/src/vector.cpp
@@ -1,0 +1,43 @@
+/**
+ * @file
+ */
+
+#include <cmath>
+#include <numbers>
+
+#include "micras/core/vector.hpp"
+
+namespace micras::core {
+float Vector::distance(const Vector& other) const {
+    return std::hypot(other.x - this->x, other.y - this->y);
+}
+
+float Vector::magnitude() const {
+    return std::hypot(this->x, this->y);
+}
+
+float Vector::angle_between(const Vector& other) const {
+    return std::atan2(other.y - this->y, other.x - this->x);
+}
+
+Vector Vector::move_towards(const Vector& other, float distance) const {
+    const float angle = this->angle_between(other);
+    return {this->x + distance * std::cos(angle), this->y + distance * std::sin(angle)};
+}
+
+Vector Vector::operator+(const Vector& other) const {
+    return {this->x + other.x, this->y + other.y};
+}
+
+Vector Vector::operator-(const Vector& other) const {
+    return {this->x - other.x, this->y - other.y};
+}
+
+bool Vector::operator==(const Vector& other) const {
+    return this->x == other.x and this->y == other.y;
+}
+
+Vector Vector::operator%(float value) const {
+    return {std::fmod(this->x, value), std::fmod(this->y, value)};
+}
+}  // namespace micras::core

--- a/micras_hal/include/micras/hal/mcu.hpp
+++ b/micras_hal/include/micras/hal/mcu.hpp
@@ -5,8 +5,6 @@
 #ifndef MICRAS_HAL_MCU_HPP
 #define MICRAS_HAL_MCU_HPP
 
-#include <cstdint>
-
 namespace micras::hal {
 /**
  * @brief Microcontroller unit class.

--- a/micras_nav/include/micras/nav/action_queuer.hpp
+++ b/micras_nav/include/micras/nav/action_queuer.hpp
@@ -5,7 +5,7 @@
 #ifndef MICRAS_NAV_ACTION_QUEUER_HPP
 #define MICRAS_NAV_ACTION_QUEUER_HPP
 
-#include <map>
+#include <list>
 #include <memory>
 #include <queue>
 
@@ -82,7 +82,7 @@ public:
     /**
      * @brief Fill the action queue with a sequence of actions to the end.
      */
-    void recompute(const std::map<uint16_t, GridPose, std::greater<>>& best_route);
+    void recompute(const std::list<GridPose>& best_route);
 
 private:
     /**

--- a/micras_nav/include/micras/nav/costmap.hpp
+++ b/micras_nav/include/micras/nav/costmap.hpp
@@ -91,10 +91,11 @@ public:
     /**
      * @brief Check whether there is a wall at the front of a given pose.
      *
-     * @param pose The pose to check.
+     * @param pose The pose to check.\
+     * @param consider_virtual Whether to consider virtual walls.
      * @return True if there is a wall, false otherwise.
      */
-    bool has_wall(const GridPose& pose) const;
+    bool has_wall(const GridPose& pose, bool consider_virtual = false) const;
 
     /**
      * @brief Update the existence of a wall in the maze.

--- a/micras_nav/include/micras/nav/costmap.hpp
+++ b/micras_nav/include/micras/nav/costmap.hpp
@@ -11,7 +11,7 @@
 #include "micras/nav/grid_pose.hpp"
 
 namespace micras::nav {
-constexpr int16_t max_cost{0x7FFF};
+constexpr int16_t max_cost{0x1FFF};
 
 /**
  * @brief Class for managing a layered costmap.
@@ -37,8 +37,10 @@ public:
      * @brief Type to store the information of a cell in the maze.
      */
     struct Cell {
+        Cell() { costs.fill(max_cost); }
+
         std::array<WallState, 4>    walls{WallState::UNKNOWN};
-        std::array<int16_t, layers> costs{max_cost};
+        std::array<int16_t, layers> costs;
     };
 
     /**

--- a/micras_nav/include/micras/nav/costmap.hpp
+++ b/micras_nav/include/micras/nav/costmap.hpp
@@ -1,0 +1,91 @@
+/**
+ * @file
+ */
+
+#ifndef MICRAS_NAV_COSTMAP_HPP
+#define MICRAS_NAV_COSTMAP_HPP
+
+#include <array>
+#include <cstdint>
+
+#include "micras/nav/grid_pose.hpp"
+
+namespace micras::nav {
+constexpr int16_t max_cost{0x7FFF};
+
+/**
+ * @brief Class for storing the robot information about the maze.
+ *
+ * @tparam width The width of the maze.
+ * @tparam height The height of the maze.
+ */
+template <uint8_t width, uint8_t height, uint8_t layers>
+class Costmap {
+public:
+    enum WallState : uint8_t {
+        UNKNOWN = 0,
+        NO_WALL = 1,
+        WALL = 2,
+        VIRTUAL = 3,
+    };
+
+    /**
+     * @brief Type to store the information of a cell in the maze.
+     */
+    struct Cell {
+        std::array<WallState, 4>    walls{WallState::UNKNOWN};
+        std::array<int16_t, layers> costs{max_cost};
+    };
+
+    Costmap();
+
+    /**
+     * @brief Calculate the costmap for the flood fill algorithm.
+     */
+    void compute(const GridPoint& reference, uint8_t layer);
+
+    /**
+     * @brief Return the cell at the given position.
+     *
+     * @param position The position of the cell.
+     * @return The cell at the given position.
+     */
+    const Cell& get_cell(const GridPoint& position) const;
+
+    int16_t get_cost(const GridPoint& position, uint8_t layer) const;
+
+    void update_cost(const GridPoint& position, uint8_t layer, int16_t cost);
+
+    /**
+     * @brief Update the existence of a wall in the maze.
+     *
+     * @param pose The pose of the robot.
+     * @param wall Whether there is a wall at the front of a given pose.
+     */
+    bool update_wall(const GridPose& pose, bool wall);
+
+    /**
+     * @brief Check whether there is a wall at the front of a given pose.
+     *
+     * @param pose The pose to check.
+     * @return True if there is a wall, false otherwise.
+     */
+    bool has_wall(const GridPose& pose) const;
+
+    void recompute(const GridPoint& reference, uint8_t layer);
+
+    void add_virtual_wall(const GridPose& pose);
+
+private:
+    Cell& get_cell(const GridPoint& position);
+
+    /**
+     * @brief Cells matrix representing the maze.
+     */
+    std::array<std::array<Cell, width>, height> cells{};
+};
+}  // namespace micras::nav
+
+#include "../src/costmap.cpp"  // NOLINT(bugprone-suspicious-include, misc-header-include-cycle)
+
+#endif  // MICRAS_NAV_COSTMAP_HPP

--- a/micras_nav/include/micras/nav/costmap.hpp
+++ b/micras_nav/include/micras/nav/costmap.hpp
@@ -14,14 +14,18 @@ namespace micras::nav {
 constexpr int16_t max_cost{0x7FFF};
 
 /**
- * @brief Class for storing the robot information about the maze.
+ * @brief Class for managing a layered costmap.
  *
  * @tparam width The width of the maze.
  * @tparam height The height of the maze.
+ * @tparam layers The number of layers in the costmap.
  */
 template <uint8_t width, uint8_t height, uint8_t layers>
 class Costmap {
 public:
+    /**
+     * @brief Type to store the state of a wall.
+     */
     enum WallState : uint8_t {
         UNKNOWN = 0,
         NO_WALL = 1,
@@ -37,12 +41,26 @@ public:
         std::array<int16_t, layers> costs{max_cost};
     };
 
+    /**
+     * @brief Construct a new Costmap object.
+     */
     Costmap();
 
     /**
-     * @brief Calculate the costmap for the flood fill algorithm.
+     * @brief Compute the costmap of a given layer from a reference point using the flood fill algorithm.
+     *
+     * @param reference The reference point to start the flood fill algorithm.
+     * @param layer The layer to compute the costmap for.
      */
     void compute(const GridPoint& reference, uint8_t layer);
+
+    /**
+     * @brief Reset the costs and recompute the new values locally for a given layer.
+     *
+     * @param reference The reference point to start resetting the stored cost.
+     * @param layer The layer to recompute.
+     */
+    void recompute(const GridPoint& reference, uint8_t layer);
 
     /**
      * @brief Return the cell at the given position.
@@ -52,9 +70,31 @@ public:
      */
     const Cell& get_cell(const GridPoint& position) const;
 
+    /**
+     * @brief Get the cost of a cell at a given position and layer.
+     *
+     * @param position The position of the cell.
+     * @param layer The layer to get the cost for.
+     * @return The cost of the cell at the given position and layer.
+     */
     int16_t get_cost(const GridPoint& position, uint8_t layer) const;
 
+    /**
+     * @brief Update the cost of a cell at a given position and layer.
+     *
+     * @param position The position of the cell.
+     * @param layer The layer to update the cost for.
+     * @param cost The new cost to set.
+     */
     void update_cost(const GridPoint& position, uint8_t layer, int16_t cost);
+
+    /**
+     * @brief Check whether there is a wall at the front of a given pose.
+     *
+     * @param pose The pose to check.
+     * @return True if there is a wall, false otherwise.
+     */
+    bool has_wall(const GridPose& pose) const;
 
     /**
      * @brief Update the existence of a wall in the maze.
@@ -65,19 +105,20 @@ public:
     bool update_wall(const GridPose& pose, bool wall);
 
     /**
-     * @brief Check whether there is a wall at the front of a given pose.
+     * @brief Add a virtual wall to the costmap at a given position and side.
      *
-     * @param pose The pose to check.
-     * @return True if there is a wall, false otherwise.
+     * @param pose The pose to add the virtual wall at.
      */
-    bool has_wall(const GridPose& pose) const;
-
-    void recompute(const GridPoint& reference, uint8_t layer);
-
     void add_virtual_wall(const GridPose& pose);
 
 private:
-    Cell& get_cell(const GridPoint& position);
+    /**
+     * @brief Get the cell at the given position.
+     *
+     * @param position The position of the cell.
+     * @return The cell at the given position.
+     */
+    Cell& cell_on_position(const GridPoint& position);
 
     /**
      * @brief Cells matrix representing the maze.

--- a/micras_nav/include/micras/nav/grid_pose.hpp
+++ b/micras_nav/include/micras/nav/grid_pose.hpp
@@ -31,20 +31,6 @@ enum Side : uint8_t {
 Side angle_to_grid(float angle);
 
 /**
- * @brief Type to store information originating from the wall sensors.
- */
-struct Information {
-    /**
-     * @brief Possible walls in the grid to be checked.
-     */
-    core::Observation left;
-    core::Observation front_left;
-    core::Observation front;
-    core::Observation front_right;
-    core::Observation right;
-};
-
-/**
  * @brief Type to store a point in the grid.
  */
 struct GridPoint {

--- a/micras_nav/include/micras/nav/grid_pose.hpp
+++ b/micras_nav/include/micras/nav/grid_pose.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 
 #include "micras/core/types.hpp"
+#include "micras/core/vector.hpp"
 
 namespace micras::nav {
 /**
@@ -54,6 +55,23 @@ struct GridPoint {
      * @return The direction from this point to the next one.
      */
     Side direction(const GridPoint& next) const;
+
+    /**
+     * @brief Convert the point to a grid point.
+     *
+     * @param cell_size The size of the grid cells.
+     * @return The grid point corresponding to the point.
+     */
+    static GridPoint from_vector(const core::Vector& point, float cell_size);
+
+    /**
+     * @brief Convert a grid point to a point.
+     *
+     * @param grid_point The grid point to convert.
+     * @param cell_size The size of the grid cells.
+     * @return The point corresponding to the grid point.
+     */
+    core::Vector to_vector(float cell_size) const;
 
     /**
      * @brief Move in the grid in the direction of the side.

--- a/micras_nav/include/micras/nav/grid_pose.hpp
+++ b/micras_nav/include/micras/nav/grid_pose.hpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <functional>
 
-#include "micras/core/types.hpp"
 #include "micras/core/vector.hpp"
 
 namespace micras::nav {

--- a/micras_nav/include/micras/nav/maze.hpp
+++ b/micras_nav/include/micras/nav/maze.hpp
@@ -6,7 +6,7 @@
 #define MICRAS_NAV_MAZE_HPP
 
 #include <cstdint>
-#include <map>
+#include <list>
 #include <unordered_set>
 
 #include "micras/core/serializable.hpp"
@@ -71,7 +71,7 @@ public:
      *
      * @return The best route to the goal.
      */
-    const std::map<uint16_t, GridPose, std::greater<>>& get_best_route() const;
+    const std::list<GridPose>& get_best_route() const;
 
     /**
      * @brief Serialize the best route to the goal.
@@ -172,7 +172,7 @@ private:
     /**
      * @brief Current best found route to the goal.
      */
-    std::map<uint16_t, GridPose, std::greater<>> best_route;
+    std::list<GridPose> best_route;
 };
 }  // namespace micras::nav
 

--- a/micras_nav/include/micras/nav/maze.hpp
+++ b/micras_nav/include/micras/nav/maze.hpp
@@ -11,6 +11,7 @@
 #include <unordered_set>
 
 #include "micras/core/serializable.hpp"
+#include "micras/core/types.hpp"
 #include "micras/nav/grid_pose.hpp"
 
 namespace micras::nav {

--- a/micras_nav/include/micras/nav/maze.hpp
+++ b/micras_nav/include/micras/nav/maze.hpp
@@ -48,7 +48,7 @@ public:
      * @param returning Whether the robot is returning to the start position.
      * @return The next point the robot should go to when exploring.
      */
-    GridPose get_next_goal(const GridPoint& position) const;
+    GridPose get_next_goal(const GridPose& pose) const;
 
     /**
      * @brief Detects walls around the robot at a given grid pose.

--- a/micras_nav/include/micras/nav/maze.hpp
+++ b/micras_nav/include/micras/nav/maze.hpp
@@ -95,7 +95,7 @@ private:
     enum Layer : uint8_t {
         EXPLORE = 0,
         RETURN = 1,
-        NUM_OF_LAYERS = 3,
+        NUM_OF_LAYERS = 2,
     };
 
     /**

--- a/micras_nav/include/micras/nav/maze.hpp
+++ b/micras_nav/include/micras/nav/maze.hpp
@@ -48,7 +48,7 @@ public:
      * @param returning Whether the robot is returning to the start position.
      * @return The next point the robot should go to when exploring.
      */
-    GridPose get_next_goal(const GridPoint& position, bool returning) const;
+    GridPose get_next_goal(const GridPoint& position) const;
 
     /**
      * @brief Detects walls around the robot at a given grid pose.
@@ -66,6 +66,8 @@ public:
      * @return True if the robot has finished the maze, false otherwise.
      */
     bool finished(const GridPoint& position, bool returning) const;
+
+    void compute_return_costmap();
 
     /**
      * @brief Calculate the best route to the goal using the current costmap.
@@ -100,13 +102,16 @@ private:
      */
     struct Cell {
         std::array<bool, 4> walls{};
-        uint16_t            cost{0xFFFF};
+        int16_t             cost{0x7FFF};
+        bool                visited{};
     };
 
     /**
      * @brief Calculate the costmap for the flood fill algorithm.
      */
-    void compute_costmap();
+    void compute_costmap(const GridPoint& reference);
+
+    void update_cost(const GridPoint& reference);
 
     /**
      * @brief Return the cell at the given position.
@@ -130,7 +135,7 @@ private:
      * @param pose The pose of the robot.
      * @param wall Whether there is a wall at the front of a given pose.
      */
-    void update_wall(const GridPose& pose, bool wall);
+    bool update_wall(const GridPose& pose, bool wall);
 
     /**
      * @brief Check whether there is a wall at the front of a given pose.

--- a/micras_nav/include/micras/nav/maze.hpp
+++ b/micras_nav/include/micras/nav/maze.hpp
@@ -65,7 +65,7 @@ public:
      * @param returning Whether the robot is returning to the start position.
      * @return True if the robot has finished the maze, false otherwise.
      */
-    bool finished(const GridPoint& position, bool returning) const;
+    bool finished(const GridPoint& position) const;
 
     void compute_return_costmap();
 
@@ -164,6 +164,8 @@ private:
      * @brief Current best found route to the goal.
      */
     std::map<uint16_t, GridPose, std::greater<>> best_route;
+
+    bool returning{};
 };
 }  // namespace micras::nav
 

--- a/micras_nav/include/micras/nav/maze.hpp
+++ b/micras_nav/include/micras/nav/maze.hpp
@@ -48,10 +48,9 @@ public:
      *
      * @param position The current position of the robot.
      * @param returning Whether the robot is returning to the start position.
-     * @param discover Whether the robot should discover new cells.
      * @return The next point the robot should go.
      */
-    GridPose get_next_goal(const GridPose& pose, bool returning, bool discover = true);
+    GridPose get_next_goal(const GridPose& pose, bool returning);
 
     /**
      * @brief Check whether the robot has finished the maze.
@@ -107,12 +106,13 @@ private:
     void update_cell(const GridPoint& position);
 
     /**
-     * @brief Get the next goal for the robot to discover more cells.
+     * @brief Get the next goal for the robot using a BFS algorithm.
      *
      * @param pose The current pose of the robot.
+     * @param discover Whether the robot is discovering new cells.
      * @return The next discovery goal for the robot.
      */
-    GridPose get_next_discovery_goal(const GridPose& pose) const;
+    GridPose get_next_bfs_goal(const GridPose& pose, bool discover) const;
 
     /**
      * @brief Check if the cell is a dead end.

--- a/micras_nav/include/micras/nav/maze.hpp
+++ b/micras_nav/include/micras/nav/maze.hpp
@@ -97,13 +97,23 @@ public:
     void deserialize(const uint8_t* buffer, uint16_t size) override;
 
 private:
+    enum WallState : uint8_t {
+        UNKNOWN = 0,
+        NO_WALL = 1,
+        WALL = 2,
+    };
+
     /**
      * @brief Type to store the information of a cell in the maze.
      */
     struct Cell {
-        std::array<bool, 4> walls{};
-        int16_t             cost{0x7FFF};
-        bool                visited{};
+        std::array<WallState, 4> walls{};
+        int16_t                  cost{0x7FFF};
+
+        bool visited() const {
+            return this->walls[Side::UP] != WallState::UNKNOWN and this->walls[Side::RIGHT] != WallState::UNKNOWN and
+                   this->walls[Side::LEFT] != WallState::UNKNOWN and this->walls[Side::DOWN] != WallState::UNKNOWN;
+        }
     };
 
     /**

--- a/micras_nav/include/micras/nav/maze.hpp
+++ b/micras_nav/include/micras/nav/maze.hpp
@@ -27,7 +27,7 @@ public:
     struct Config {
         GridPose                      start{};
         std::unordered_set<GridPoint> goal;
-        uint16_t                      cost_margin{};
+        float                         cost_margin{};
     };
 
     /**
@@ -157,7 +157,7 @@ private:
     /**
      * @brief Cost margin above the minimum cost that the robot should explore.
      */
-    uint16_t cost_margin;
+    float cost_margin;
 
     /**
      * @brief Minimum cost of path to the goal containing only visited cells.

--- a/micras_nav/include/micras/nav/odometry.hpp
+++ b/micras_nav/include/micras/nav/odometry.hpp
@@ -5,7 +5,6 @@
 #ifndef MICRAS_NAV_ODOMETRY_HPP
 #define MICRAS_NAV_ODOMETRY_HPP
 
-#include <cstdint>
 #include <memory>
 
 #include "micras/core/butterworth_filter.hpp"

--- a/micras_nav/include/micras/nav/odometry.hpp
+++ b/micras_nav/include/micras/nav/odometry.hpp
@@ -37,8 +37,8 @@ public:
      * @param config Configuration for the odometry.
      */
     Odometry(
-        const std::shared_ptr<proxy::RotarySensor>& left_rotary_sensor,
-        const std::shared_ptr<proxy::RotarySensor>& right_rotary_sensor, const std::shared_ptr<proxy::Imu>& imu,
+        const std::shared_ptr<const proxy::RotarySensor>& left_rotary_sensor,
+        const std::shared_ptr<const proxy::RotarySensor>& right_rotary_sensor, const std::shared_ptr<proxy::Imu>& imu,
         Config config
     );
 
@@ -72,12 +72,12 @@ private:
     /**
      * @brief Left rotary sensor.
      */
-    std::shared_ptr<proxy::RotarySensor> left_rotary_sensor;
+    std::shared_ptr<const proxy::RotarySensor> left_rotary_sensor;
 
     /**
      * @brief Right rotary sensor.
      */
-    std::shared_ptr<proxy::RotarySensor> right_rotary_sensor;
+    std::shared_ptr<const proxy::RotarySensor> right_rotary_sensor;
 
     /**
      * @brief IMU sensor.

--- a/micras_nav/include/micras/nav/state.hpp
+++ b/micras_nav/include/micras/nav/state.hpp
@@ -5,105 +5,10 @@
 #ifndef MICRAS_NAV_POSE_HPP
 #define MICRAS_NAV_POSE_HPP
 
+#include "micras/core/vector.hpp"
 #include "micras/nav/grid_pose.hpp"
 
 namespace micras::nav {
-/**
- * @brief Type to store a point in 2D space.
- */
-struct Point {
-    /**
-     * @brief Calculate the distance to another point.
-     *
-     * @param other The other point.
-     * @return The distance to the other point.
-     */
-    float distance(const Point& other) const;
-
-    /**
-     * @brief Calculate the distance of the point to the origin.
-     *
-     * @return The distance of the point to the origin.
-     */
-    float magnitude() const;
-
-    /**
-     * @brief Calculate the angle between two points.
-     *
-     * @param other The other point.
-     * @return The angle between the two points.
-     */
-    float angle_between(const Point& other) const;
-
-    /**
-     * @brief Convert the point to a grid point.
-     *
-     * @param cell_size The size of the grid cells.
-     * @return The grid point corresponding to the point.
-     */
-    GridPoint to_grid(float cell_size) const;
-
-    /**
-     * @brief Move the point towards another point by a given distance.
-     *
-     * @param other The point to move towards.
-     * @param distance The distance to move.
-     * @return The point after moving towards the other point.
-     */
-    Point move_towards(const Point& other, float distance) const;
-
-    /**
-     * @brief Add a point to another.
-     *
-     * @param other The point to add.
-     * @return The result of the addition.
-     */
-    Point operator+(const Point& other) const;
-
-    /**
-     * @brief Subtract a point from another.
-     *
-     * @param other The point to subtract.
-     * @return The result of the subtraction.
-     */
-    Point operator-(const Point& other) const;
-
-    /**
-     * @brief Compare two points for equality.
-     *
-     * @param other The other point to compare.
-     * @return True if the points are equal, false otherwise.
-     */
-    bool operator==(const Point& other) const;
-
-    /**
-     * @brief Calculate the remainder of the division of the point by a value.
-     *
-     * @param value The value to divide the point by.
-     * @return The remainder of the division.
-     */
-    Point operator%(float value) const;
-
-    /**
-     * @brief Convert a grid point to a point.
-     *
-     * @param grid_point The grid point to convert.
-     * @param cell_size The size of the grid cells.
-     * @return The point corresponding to the grid point.
-     */
-    static Point from_grid(const GridPoint& grid_point, float cell_size);
-
-    /**
-     * @brief The x coordinate of the point in 2D space.
-     */
-    float x;
-
-    /**
-     * @brief The y coordinate of the point in 2D space.
-     */
-    float y;
-};
-
 /**
  * @brief Type to store a pose in 2D space.
  */
@@ -122,12 +27,12 @@ struct Pose {
      * @param cell_size The size of the grid cells.
      * @return The point inside the cell reference.
      */
-    Point to_cell(float cell_size) const;
+    core::Vector to_cell(float cell_size) const;
 
     /**
      * @brief The position of the pose.
      */
-    Point position;
+    core::Vector position;
 
     /**
      * @brief The orientation of the pose.

--- a/micras_nav/src/action_queuer.cpp
+++ b/micras_nav/src/action_queuer.cpp
@@ -76,7 +76,7 @@ bool ActionQueuer::empty() const {
     return this->action_queue.empty();
 }
 
-void ActionQueuer::recompute(const std::map<uint16_t, GridPose, std::greater<>>& best_route) {
+void ActionQueuer::recompute(const std::list<GridPose>& best_route) {
     this->action_queue = {};
     this->action_queue.emplace(start);
 
@@ -85,7 +85,7 @@ void ActionQueuer::recompute(const std::map<uint16_t, GridPose, std::greater<>>&
     }
 
     for (auto it = std::next(best_route.begin()); std::next(it) != best_route.end(); it++) {
-        this->push(it->second, std::next(it)->second.position);
+        this->push(*it, std::next(it)->position);
     }
 }
 }  // namespace micras::nav

--- a/micras_nav/src/costmap.cpp
+++ b/micras_nav/src/costmap.cpp
@@ -112,8 +112,9 @@ void Costmap<width, height, layers>::update_cost(const GridPoint& position, uint
 }
 
 template <uint8_t width, uint8_t height, uint8_t layers>
-bool Costmap<width, height, layers>::has_wall(const GridPose& pose) const {
-    return this->get_cell(pose.position).walls[pose.orientation] == WallState::WALL;
+bool Costmap<width, height, layers>::has_wall(const GridPose& pose, bool consider_virtual) const {
+    return this->get_cell(pose.position).walls[pose.orientation] == WallState::WALL or
+           (consider_virtual and this->get_cell(pose.position).walls[pose.orientation] == WallState::VIRTUAL);
 }
 
 template <uint8_t width, uint8_t height, uint8_t layers>

--- a/micras_nav/src/costmap.cpp
+++ b/micras_nav/src/costmap.cpp
@@ -109,7 +109,7 @@ bool Costmap<width, height, layers>::has_wall(const GridPose& pose, bool conside
 
 template <uint8_t width, uint8_t height, uint8_t layers>
 bool Costmap<width, height, layers>::update_wall(const GridPose& pose, bool wall) {
-    if (this->has_wall(pose)) {
+    if (this->has_wall(pose, true)) {
         return false;
     }
 

--- a/micras_nav/src/costmap.cpp
+++ b/micras_nav/src/costmap.cpp
@@ -1,0 +1,152 @@
+/**
+ * @file
+ */
+
+#ifndef MICRAS_NAV_COSTMAP_CPP
+#define MICRAS_NAV_COSTMAP_CPP
+
+#include <cmath>
+#include <list>
+#include <queue>
+
+#include "micras/nav/costmap.hpp"
+
+namespace micras::nav {
+template <uint8_t width, uint8_t height, uint8_t layers>
+Costmap<width, height, layers>::Costmap() {
+    for (uint8_t row = 0; row < height; row++) {
+        this->cells[row][0].walls[Side::LEFT] = WallState::WALL;
+        this->cells[row][width - 1].walls[Side::RIGHT] = WallState::WALL;
+    }
+
+    for (uint8_t col = 0; col < width; col++) {
+        this->cells[0][col].walls[Side::DOWN] = WallState::WALL;
+        this->cells[height - 1][col].walls[Side::UP] = WallState::WALL;
+    }
+}
+
+template <uint8_t width, uint8_t height, uint8_t layers>
+const Costmap<width, height, layers>::Cell& Costmap<width, height, layers>::get_cell(const GridPoint& position) const {
+    return this->cells.at(position.y).at(position.x);
+}
+
+template <uint8_t width, uint8_t height, uint8_t layers>
+Costmap<width, height, layers>::Cell& Costmap<width, height, layers>::get_cell(const GridPoint& position) {
+    return this->cells.at(position.y).at(position.x);
+}
+
+template <uint8_t width, uint8_t height, uint8_t layers>
+void Costmap<width, height, layers>::update_cost(const GridPoint& position, uint8_t layer, int16_t cost) {
+    this->get_cell(position).costs.at(layer) = cost;
+}
+
+template <uint8_t width, uint8_t height, uint8_t layers>
+bool Costmap<width, height, layers>::update_wall(const GridPose& pose, bool wall) {
+    if (pose.position.x >= width or pose.position.y >= height or this->has_wall(pose)) {
+        return false;
+    }
+
+    const bool updated = wall;
+    this->get_cell(pose.position).walls[pose.orientation] = wall ? WallState::WALL : WallState::NO_WALL;
+
+    GridPose front_pose = pose.front();
+
+    if (front_pose.position.x >= width or front_pose.position.y >= height) {
+        return updated;
+    }
+
+    this->get_cell(front_pose.position).walls[pose.turned_back().orientation] =
+        wall ? WallState::WALL : WallState::NO_WALL;
+
+    return updated;
+}
+
+template <uint8_t width, uint8_t height, uint8_t layers>
+void Costmap<width, height, layers>::compute(const GridPoint& reference, uint8_t layer) {
+    std::queue<GridPoint> queue;
+    queue.push(reference);
+
+    while (not queue.empty()) {
+        GridPoint current_position = queue.front();
+        queue.pop();
+
+        for (uint8_t i = Side::RIGHT; i <= Side::DOWN; i++) {
+            Side      side = static_cast<Side>(i);
+            GridPoint front_position = current_position + side;
+
+            if (not this->has_wall({current_position, side})) {
+                int16_t new_cost = this->get_cost(current_position, layer) + 1;
+
+                if (this->get_cost(front_position, layer) > new_cost) {
+                    this->update_cost(front_position, layer, new_cost);
+                    queue.push(front_position);
+                }
+            }
+        }
+    }
+}
+
+template <uint8_t width, uint8_t height, uint8_t layers>
+void Costmap<width, height, layers>::recompute(const GridPoint& reference, uint8_t layer) {
+    std::queue<GridPoint> queue;
+    std::list<GridPoint>  compute_list;
+    queue.push(reference);
+
+    while (not queue.empty()) {
+        GridPoint current_position = queue.front();
+        queue.pop();
+        bool reset_cost = true;
+
+        for (uint8_t i = Side::RIGHT; i <= Side::DOWN; i++) {
+            Side      side = static_cast<Side>(i);
+            GridPoint front_position = current_position + side;
+
+            if (not this->has_wall({current_position, side}) and
+                this->get_cost(current_position, layer) == this->get_cost(front_position, layer) + 1) {
+                compute_list.emplace_back(current_position);
+                reset_cost = false;
+                break;
+            }
+        }
+
+        if (not reset_cost) {
+            continue;
+        }
+
+        uint16_t old_cost = this->get_cost(current_position, layer);
+        this->update_cost(current_position, layer, max_cost);
+
+        for (uint8_t i = Side::RIGHT; i <= Side::DOWN; i++) {
+            Side      side = static_cast<Side>(i);
+            GridPoint front_position = current_position + side;
+
+            if (not this->has_wall({current_position, side}) and
+                this->get_cost(front_position, layer) == old_cost + 1) {
+                queue.push(front_position);
+            }
+        }
+    }
+
+    for (const auto& position : compute_list) {
+        this->compute(position, layer);
+    }
+}
+
+template <uint8_t width, uint8_t height, uint8_t layers>
+bool Costmap<width, height, layers>::has_wall(const GridPose& pose) const {
+    return this->get_cell(pose.position).walls[pose.orientation] == WallState::WALL;
+}
+
+template <uint8_t width, uint8_t height, uint8_t layers>
+int16_t Costmap<width, height, layers>::get_cost(const GridPoint& position, uint8_t layer) const {
+    return this->get_cell(position).costs[layer];
+}
+
+template <uint8_t width, uint8_t height, uint8_t layers>
+void Costmap<width, height, layers>::add_virtual_wall(const GridPose& pose) {
+    this->get_cell(pose.position).walls[pose.orientation] = WallState::VIRTUAL;
+    this->get_cell(pose.position).walls[pose.turned_back().orientation] = WallState::VIRTUAL;
+}
+}  // namespace micras::nav
+
+#endif  // MICRAS_NAV_COSTMAP_CPP

--- a/micras_nav/src/costmap.cpp
+++ b/micras_nav/src/costmap.cpp
@@ -57,7 +57,7 @@ void Costmap<width, height, layers>::recompute(const GridPoint& reference, uint8
     while (not queue.empty()) {
         GridPoint current_position = queue.front();
         queue.pop();
-        int16_t lowest_cost = max_cost - 1;
+        int16_t lowest_cost = max_cost;
 
         for (uint8_t i = Side::RIGHT; i <= Side::DOWN; i++) {
             Side side = static_cast<Side>(i);

--- a/micras_nav/src/follow_wall.cpp
+++ b/micras_nav/src/follow_wall.cpp
@@ -18,6 +18,10 @@ FollowWall::FollowWall(
     post_clearance{config.post_clearance} { }
 
 float FollowWall::compute_angular_correction(float elapsed_time, float linear_speed) {
+    if (this->wall_sensors.use_count() == 1) {
+        this->wall_sensors->update();
+    }
+
     if (this->check_posts()) {
         return 0.0F;
     }

--- a/micras_nav/src/grid_pose.cpp
+++ b/micras_nav/src/grid_pose.cpp
@@ -32,6 +32,14 @@ Side GridPoint::direction(const GridPoint& next) const {
     return Side::UP;
 }
 
+GridPoint GridPoint::from_vector(const core::Vector& point, float cell_size) {
+    return {static_cast<uint8_t>(point.x / cell_size), static_cast<uint8_t>(point.y / cell_size)};
+}
+
+core::Vector GridPoint::to_vector(float cell_size) const {
+    return {cell_size * (this->x + 0.5F), cell_size * (this->y + 0.5F)};
+}
+
 GridPoint GridPoint::operator+(const Side& side) const {
     switch (side) {
         case Side::RIGHT:

--- a/micras_nav/src/maze.cpp
+++ b/micras_nav/src/maze.cpp
@@ -191,7 +191,7 @@ void TMaze<width, height>::compute_costmap(const GridPoint& reference) {
             GridPoint front_position = current_position + side;
 
             if (not this->has_wall({current_position, side})) {
-                uint16_t new_cost =
+                int16_t new_cost =
                     current_cell.cost + 1 -
                     (this->returning and current_cell.visited() and not this->get_cell(front_position).visited() ?
                          width + height :

--- a/micras_nav/src/maze.cpp
+++ b/micras_nav/src/maze.cpp
@@ -71,6 +71,7 @@ void TMaze<width, height>::update_walls(const GridPose& pose, const core::Observ
 template <uint8_t width, uint8_t height>
 GridPose TMaze<width, height>::get_next_goal(const GridPose& pose, bool returning) {
     if (returning and not this->finished_discovery) {
+        this->compute_best_route();
         const auto& next_goal = this->get_next_bfs_goal(pose, true);
 
         if (next_goal != this->start) {
@@ -200,7 +201,9 @@ GridPose TMaze<width, height>::get_next_bfs_goal(const GridPose& pose, bool disc
         checked.at(current_pose.position.y).at(current_pose.position.x) = true;
 
         if ((discover and
-             this->must_visit(this->costmap.get_cell(current_pose.position), this->minimum_cost + this->cost_margin)) or
+             this->must_visit(
+                 this->costmap.get_cell(current_pose.position), std::round(this->minimum_cost * this->cost_margin)
+             )) or
             (not discover and this->goal.contains(current_pose.position))) {
             next_goal = {pose.position + current_pose.orientation, current_pose.orientation};
             break;

--- a/micras_nav/src/maze.cpp
+++ b/micras_nav/src/maze.cpp
@@ -199,10 +199,9 @@ void TMaze<width, height>::compute_costmap(const GridPoint& reference) {
 
             if (not this->has_wall({current_position, side})) {
                 int16_t new_cost =
-                    current_cell.cost + 1 -
                     (this->returning and current_cell.visited() and not this->get_cell(front_position).visited() ?
-                         std::lround(std::hypot(width, height)) :
-                         0);
+                         -(width + height) / 2 :
+                         current_cell.cost + 1);
 
                 if (this->get_cell(front_position).cost > new_cost) {
                     this->get_cell(front_position).cost = new_cost;

--- a/micras_nav/src/maze.cpp
+++ b/micras_nav/src/maze.cpp
@@ -6,7 +6,6 @@
 #define MICRAS_NAV_MAZE_CPP
 
 #include <cmath>
-#include <iterator>
 #include <queue>
 
 #include "micras/nav/maze.hpp"

--- a/micras_nav/src/maze.cpp
+++ b/micras_nav/src/maze.cpp
@@ -75,7 +75,7 @@ void TMaze<width, height>::update_walls(const GridPose& pose, const core::Observ
 
 template <uint8_t width, uint8_t height>
 GridPose TMaze<width, height>::get_next_goal(const GridPose& pose) const {
-    uint16_t current_cost = 0x7FFF;
+    int16_t  current_cost = 0x7FFF;
     GridPose next_pose = {};
 
     for (uint8_t i = Side::RIGHT; i <= Side::DOWN; i++) {
@@ -110,7 +110,7 @@ bool TMaze<width, height>::update_wall(const GridPose& pose, bool wall) {
         return false;
     }
 
-    bool updated = wall;
+    const bool updated = wall;
     this->get_cell(pose.position).walls[pose.orientation] = wall ? WallState::WALL : WallState::NO_WALL;
 
     GridPose front_pose = pose.front();

--- a/micras_nav/src/maze.cpp
+++ b/micras_nav/src/maze.cpp
@@ -26,7 +26,7 @@ TMaze<width, height>::TMaze(Config config) : start{config.start}, goal{config.go
     this->update_wall(start.turned_right(), true);
 
     // Hardcoded walls at the end region
-    if (width == 16 and height == 16) {
+    if constexpr (width == 16 and height == 16) {
         this->update_wall({{7, 7}, Side::DOWN}, true);
         this->update_wall({{8, 7}, Side::DOWN}, true);
         // this->update_wall({{8, 7}, Side::RIGHT}, true);
@@ -117,7 +117,11 @@ bool TMaze<width, height>::has_wall(const GridPose& pose) const {
 
 template <uint8_t width, uint8_t height>
 core::Observation TMaze<width, height>::get_observation(const GridPose& pose) const {
-    return {this->has_wall(pose.turned_left()), this->has_wall(pose), this->has_wall(pose.turned_right())};
+    return {
+        .left = this->has_wall(pose.turned_left()),
+        .front = this->has_wall(pose),
+        .right = this->has_wall(pose.turned_right())
+    };
 }
 
 template <uint8_t width, uint8_t height>

--- a/micras_nav/src/maze.cpp
+++ b/micras_nav/src/maze.cpp
@@ -5,6 +5,7 @@
 #ifndef MICRAS_NAV_MAZE_CPP
 #define MICRAS_NAV_MAZE_CPP
 
+#include <cmath>
 #include <iterator>
 #include <queue>
 
@@ -84,8 +85,8 @@ GridPose TMaze<width, height>::get_next_goal(const GridPose& pose) const {
     GridPose next_pose = {};
 
     for (Side side :
-         {pose.orientation.turned_right(), pose.orientation.turned_left(), pose.orientation,
-          pose.orientation.turned_back()}) {
+         {pose.turned_right().orientation, pose.turned_left().orientation, pose.orientation,
+          pose.turned_back().orientation}) {
         GridPoint front_position = pose.position + side;
         int16_t   flip_cost = pose.turned_back().orientation == side ? 1 : 0;
 

--- a/micras_nav/src/maze.cpp
+++ b/micras_nav/src/maze.cpp
@@ -42,7 +42,10 @@ TMaze<width, height>::TMaze(Config config) : start{config.start}, goal{config.go
     }
 
     this->get_cell(this->start.position).visited = true;
-    this->compute_costmap(*(this->goal.begin()));
+
+    for (const auto& position : this->goal) {
+        this->compute_costmap(position);
+    }
 }
 
 template <uint8_t width, uint8_t height>
@@ -61,13 +64,16 @@ void TMaze<width, height>::update_walls(const GridPose& pose, const core::Observ
 
     if (this->returning) {
         this->get_cell(this->start.position).cost = 0;
+        this->compute_costmap(this->start.position);
     } else {
         for (const auto& position : this->goal) {
             this->get_cell(position).cost = 0;
         }
-    }
 
-    this->compute_costmap(this->returning ? this->start.position : *(this->goal.begin()));
+        for (const auto& position : this->goal) {
+            this->compute_costmap(position);
+        }
+    }
 }
 
 template <uint8_t width, uint8_t height>

--- a/micras_nav/src/odometry.cpp
+++ b/micras_nav/src/odometry.cpp
@@ -10,8 +10,8 @@
 
 namespace micras::nav {
 Odometry::Odometry(
-    const std::shared_ptr<proxy::RotarySensor>& left_rotary_sensor,
-    const std::shared_ptr<proxy::RotarySensor>& right_rotary_sensor, const std::shared_ptr<proxy::Imu>& imu,
+    const std::shared_ptr<const proxy::RotarySensor>& left_rotary_sensor,
+    const std::shared_ptr<const proxy::RotarySensor>& right_rotary_sensor, const std::shared_ptr<proxy::Imu>& imu,
     Config config
 ) :
     left_rotary_sensor{left_rotary_sensor},
@@ -24,6 +24,10 @@ Odometry::Odometry(
     state{config.initial_pose, {0.0F, 0.0F}} { }
 
 void Odometry::update(float elapsed_time) {
+    if (this->imu.use_count() == 1) {
+        this->imu->update();
+    }
+
     const float left_position = this->left_rotary_sensor->get_position();
     const float right_position = this->right_rotary_sensor->get_position();
 

--- a/micras_nav/src/odometry.cpp
+++ b/micras_nav/src/odometry.cpp
@@ -3,9 +3,7 @@
  */
 
 #include <cmath>
-#include <numbers>
 
-#include "micras/core/utils.hpp"
 #include "micras/nav/odometry.hpp"
 
 namespace micras::nav {

--- a/micras_nav/src/speed_controller.cpp
+++ b/micras_nav/src/speed_controller.cpp
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <cmath>
 
-#include "micras/core/utils.hpp"
 #include "micras/nav/speed_controller.hpp"
 
 namespace micras::nav {

--- a/micras_nav/src/state.cpp
+++ b/micras_nav/src/state.cpp
@@ -8,53 +8,12 @@
 #include "micras/nav/state.hpp"
 
 namespace micras::nav {
-float Point::distance(const Point& other) const {
-    return std::hypot(other.x - this->x, other.y - this->y);
-}
-
-float Point::magnitude() const {
-    return std::hypot(this->x, this->y);
-}
-
-float Point::angle_between(const Point& other) const {
-    return std::atan2(other.y - this->y, other.x - this->x);
-}
-
-GridPoint Point::to_grid(float cell_size) const {
-    return {static_cast<uint8_t>(this->x / cell_size), static_cast<uint8_t>(this->y / cell_size)};
-}
-
-Point Point::move_towards(const Point& other, float distance) const {
-    const float angle = this->angle_between(other);
-    return {this->x + distance * std::cos(angle), this->y + distance * std::sin(angle)};
-}
-
-Point Point::operator+(const Point& other) const {
-    return {this->x + other.x, this->y + other.y};
-}
-
-Point Point::operator-(const Point& other) const {
-    return {this->x - other.x, this->y - other.y};
-}
-
-bool Point::operator==(const Point& other) const {
-    return this->x == other.x and this->y == other.y;
-}
-
-Point Point::operator%(float value) const {
-    return {std::fmod(this->x, value), std::fmod(this->y, value)};
-}
-
-Point Point::from_grid(const GridPoint& grid_point, float cell_size) {
-    return {cell_size * (grid_point.x + 0.5F), cell_size * (grid_point.y + 0.5F)};
-}
-
 GridPose Pose::to_grid(float cell_size) const {
-    return {this->position.to_grid(cell_size), angle_to_grid(this->orientation)};
+    return {GridPoint::from_vector(this->position, cell_size), angle_to_grid(this->orientation)};
 };
 
-Point Pose::to_cell(float cell_size) const {
-    const Point cell_position = this->position % cell_size;
+core::Vector Pose::to_cell(float cell_size) const {
+    const core::Vector cell_position = this->position % cell_size;
 
     float cell_advance = 0.0F;
     float cell_alignment = 0.0F;

--- a/micras_nav/src/state.cpp
+++ b/micras_nav/src/state.cpp
@@ -3,7 +3,6 @@
  */
 
 #include <cmath>
-#include <numbers>
 
 #include "micras/nav/state.hpp"
 

--- a/micras_proxy/src/battery.cpp
+++ b/micras_proxy/src/battery.cpp
@@ -2,7 +2,6 @@
  * @file
  */
 
-#include "micras/core/utils.hpp"
 #include "micras/proxy/battery.hpp"
 
 namespace micras::proxy {

--- a/micras_proxy/src/dip_switch.cpp
+++ b/micras_proxy/src/dip_switch.cpp
@@ -6,7 +6,6 @@
 #define MICRAS_PROXY_DIP_SWITCH_CPP
 
 #include "micras/core/utils.hpp"
-#include "micras/hal/mcu.hpp"
 #include "micras/proxy/dip_switch.hpp"
 
 namespace micras::proxy {

--- a/micras_proxy/src/imu.cpp
+++ b/micras_proxy/src/imu.cpp
@@ -3,7 +3,6 @@
  */
 
 #include <cmath>
-#include <numbers>
 
 #include "micras/proxy/imu.hpp"
 #include "micras/proxy/stopwatch.hpp"

--- a/src/micras.cpp
+++ b/src/micras.cpp
@@ -78,7 +78,7 @@ bool Micras::calibrate() {
 
 void Micras::prepare() {
     if (this->objective == core::Objective::EXPLORE) {
-        this->grid_pose = this->maze.get_next_goal(this->grid_pose);
+        this->grid_pose = this->maze.get_next_goal(this->grid_pose, false);
         this->action_queuer.recompute({});
         this->current_action = this->action_queuer.pop();
     } else {
@@ -98,7 +98,7 @@ bool Micras::run() {
             this->locomotion.stop();
 
             if (this->objective == core::Objective::EXPLORE) {
-                this->maze.compute_return_costmap();
+                this->maze.enable_discovery_costmap();
             }
 
             return true;
@@ -110,6 +110,7 @@ bool Micras::run() {
         if (not this->action_queuer.empty()) {
             this->current_action = this->action_queuer.pop();
         } else {
+            const bool returning = (this->objective == core::Objective::RETURN);
             const bool solving = (this->objective == core::Objective::SOLVE);
 
             if (not solving) {
@@ -119,11 +120,11 @@ bool Micras::run() {
 
             micras::nav::GridPose next_goal{};
 
-            if (solving or this->maze.finished(this->grid_pose.position)) {
+            if (solving or this->maze.finished(this->grid_pose.position, returning)) {
                 this->finished = true;
                 next_goal = this->grid_pose.turned_back().front();
             } else {
-                next_goal = this->maze.get_next_goal(this->grid_pose);
+                next_goal = this->maze.get_next_goal(this->grid_pose, returning);
             }
 
             this->action_queuer.push(this->grid_pose, next_goal.position);

--- a/src/micras.cpp
+++ b/src/micras.cpp
@@ -93,13 +93,11 @@ bool Micras::run() {
     core::Observation         observation{};
 
     if (this->current_action->finished(this->action_pose.get())) {
-        const bool returning = (this->objective == core::Objective::RETURN);
-
         if (this->finished) {
             this->finished = false;
             this->locomotion.stop();
 
-            if (returning) {
+            if (this->objective == core::Objective::RETURN) {
                 this->maze.compute_return_costmap();
             }
 
@@ -121,7 +119,7 @@ bool Micras::run() {
 
             micras::nav::GridPose next_goal{};
 
-            if (solving or this->maze.finished(this->grid_pose.position, returning)) {
+            if (solving or this->maze.finished(this->grid_pose.position)) {
                 this->finished = true;
                 next_goal = this->grid_pose.turned_back().front();
             } else {

--- a/src/micras.cpp
+++ b/src/micras.cpp
@@ -98,7 +98,7 @@ bool Micras::run() {
             this->locomotion.stop();
 
             if (this->objective == core::Objective::EXPLORE) {
-                this->maze.enable_discovery_costmap();
+                this->maze.compute_best_route();
             }
 
             return true;

--- a/src/micras.cpp
+++ b/src/micras.cpp
@@ -78,7 +78,7 @@ bool Micras::calibrate() {
 
 void Micras::prepare() {
     if (this->objective == core::Objective::EXPLORE) {
-        this->grid_pose = this->maze.get_next_goal(this->grid_pose.position);
+        this->grid_pose = this->maze.get_next_goal(this->grid_pose);
         this->action_queuer.recompute({});
         this->current_action = this->action_queuer.pop();
     } else {
@@ -123,7 +123,7 @@ bool Micras::run() {
                 this->finished = true;
                 next_goal = this->grid_pose.turned_back().front();
             } else {
-                next_goal = this->maze.get_next_goal(this->grid_pose.position);
+                next_goal = this->maze.get_next_goal(this->grid_pose);
             }
 
             this->action_queuer.push(this->grid_pose, next_goal.position);

--- a/src/micras.cpp
+++ b/src/micras.cpp
@@ -97,7 +97,7 @@ bool Micras::run() {
             this->finished = false;
             this->locomotion.stop();
 
-            if (this->objective == core::Objective::RETURN) {
+            if (this->objective == core::Objective::EXPLORE) {
                 this->maze.compute_return_costmap();
             }
 

--- a/src/micras.cpp
+++ b/src/micras.cpp
@@ -174,6 +174,13 @@ void Micras::reset() {
     this->finished = false;
 }
 
+bool Micras::check_crash() const {
+    return std::hypot(
+               this->imu->get_linear_acceleration(proxy::Imu::Axis::X),
+               this->imu->get_linear_acceleration(proxy::Imu::Axis::Y)
+           ) > crash_acceleration;
+}
+
 void Micras::save_best_route() {
     this->maze_storage.create("maze", this->maze);
     this->maze_storage.save();

--- a/tests/include/test_core.hpp
+++ b/tests/include/test_core.hpp
@@ -5,6 +5,7 @@
 #ifndef MICRAS_TEST_CORE_HPP
 #define MICRAS_TEST_CORE_HPP
 
+#include "micras/hal/mcu.hpp"
 #include "target.hpp"
 
 namespace micras {

--- a/tests/src/nav/test_calibrate_feed_forward.cpp
+++ b/tests/src/nav/test_calibrate_feed_forward.cpp
@@ -5,7 +5,6 @@
 #include <array>
 
 #include "constants.hpp"
-#include "micras/nav/follow_wall.hpp"
 #include "test_core.hpp"
 
 using namespace micras;  // NOLINT(google-build-using-namespace)


### PR DESCRIPTION
Essa PR adiciona um novo algoritmo de retorno usando um layered costmap, alguns pontos principais sobre o funcionamento:

- Na exploração o robô faz as mesmas coisas que fazia antes, utiliza um flood fill para encontrar o menor caminho até as células finais, e para isso utiliza um costmap que está na camada EXPLORE.

- Agora o costmap não é recalculado todas as vezes, somente as células afetas pela adição da nova parede são recalculadas.

- Ao chegar no fim do labirinto, a menor rota é calculada utilizando somente células que já foram visitadas, o custo total dessa rota é armazenado e ela é prontamente salva na memória flash (Não precisa mais terminar de retornar)

- A segunda camada do costmap é a de RETURN, que é calculada em direção ao começo do labirinto, ao invés de direcionada ao fim, sempre que o robô quiser voltar para o começo, basta seguir essa camada.

- Foi adicionado um algoritmo de remoção de dead ends, que encontra células com 3 paredes e adiciona uma parede virtual fechando ela, e repetindo o processo para as células adjacentes caso isso gere novos dead ends.

- Antes de retornar ao inicio do labirinto, o robô vai até a célula mais próxima que deve ser visitada, que é encontrada realizando um BFS a partir do robô.

- Para decidir se uma célula deve ser visitada são necessárias que duas condições sejam cumpridas: 
  - A célula não pode já ter sido visitada, o que é decidido a partir do número de paredes desconhecidas dela.
  - O custo total da célula (Soma do custo nas duas camadas) deve ser menor do que o custo do menor caminho (armazenado anteriormente) vezes uma margem que pode ser calibrada. Ou seja, células muito distantes do começo e do fim não precisam ser visitadas, e a margem existe já que o custo que vem do flood fill não representa com precisão o custo real para se chegar ao fim do labirinto.

- Quando o robô termina de visitar todas as células que deviam ser visitadas uma flag é ativada, e ele passa a ir em direção ao começo do labirinto.