### PR TITLE
Fix/single clang warning

### DIFF
--- a/cmake/templates/run_clang_tidy.sh.in
+++ b/cmake/templates/run_clang_tidy.sh.in
@@ -22,7 +22,7 @@ ERRORS=$(
         done
 
         wait
-    } | grep -v ' warnings generated\.$' | awk '!seen[$0]++'
+    } | grep -Ev '[0-9]+ warnings? generated\.$' | awk '!seen[$0]++'
 )
 
 if [[ -n "$ERRORS" ]]; then


### PR DESCRIPTION
O clang-tidy printa "N warnings generated" mesmo quando são suppressed. O script filtra essa linha, mas o grep só pegava plural ("warnings"), então com exatamente 1 warning suppressed o script falhava